### PR TITLE
Fix PDF.js CDN integrity hashes

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,8 +88,18 @@
       </main>
     </div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.6.172/pdf.min.js" integrity="sha512-kxgxN6FlMpsJtHwiuXt8n+xusLIDKcsG5Gs6w9ekP3snXTqE5QVOPnoUcwm7t7YAGq+ry7F81kD+bBZ5udAo8A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.6.172/pdf.worker.min.js" integrity="sha512-w0d6JTWT++YUANveBqqT/fdU5EHhONCoY1kfY0nSV4WJSOhO3w+z9icR4beZEZph7j86Khd4Ib8DYPJAfggFng==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.6.172/pdf.min.js"
+      integrity="sha512-KEoL9wKXt/fhlAfN+ZNXf3pI48aaQE9Qd5fihHY+5n5XLTSnyGJ0uKgUj//V6KAcjFwzAbCYYPKeGlFES/H5Ng=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    ></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.6.172/pdf.worker.min.js"
+      integrity="sha512-Dpeau+qELRm1XP/EtXrPkPMYceOlFdrIIoyJr/F7ct8PFDcfviRJm3yLXuUlFIVfT3pBDp3Sc7QYo8zn9Na13A=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    ></script>
     <script defer src="script.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- update the PDF.js and worker CDN tags with the correct SRI hashes so the browser can load them

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1183efc988324a9acb591036b8fd0