### PR TITLE
Fix mobile search drawer toggle behavior

### DIFF
--- a/script.js
+++ b/script.js
@@ -73,10 +73,17 @@ document.addEventListener('DOMContentLoaded', () => {
     document.body.appendChild(mobileListToggle);
 
     const toggleFacilityList = (forceState) => {
-        if (isMobile()) {
-            const isOpen = facilityList.classList.toggle('open', forceState);
-            mobileListToggle.innerHTML = isOpen ? '&times;' : '&#9776;';
+        if (!isMobile()) return;
+
+        let isOpen;
+        if (typeof forceState === 'boolean') {
+            facilityList.classList.toggle('open', forceState);
+            isOpen = forceState;
+        } else {
+            isOpen = facilityList.classList.toggle('open');
         }
+
+        mobileListToggle.innerHTML = isOpen ? '&times;' : '&#9776;';
     };
 
     mobileListToggle.addEventListener('click', () => toggleFacilityList());
@@ -85,6 +92,8 @@ document.addEventListener('DOMContentLoaded', () => {
             toggleFacilityList(); // Allow handle to toggle, not just open
         }
     });
+
+    searchBox.addEventListener('focus', () => toggleFacilityList(true));
 
     const zoneMap = {
         '01': '環球集市 (Global Fair)', '02': '美洲冒險 (American Adventure)', '03': '魔術天地 (Magic Land)',


### PR DESCRIPTION
## Summary
- correct the mobile facility list toggle logic so the panel can open and close
- keep the toggle button icon in sync with the drawer state and auto-open when focusing the search box

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e141f4f85c83249ca801c06c49a328