### PR TITLE
Improve mobile menu modal layout and close button

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,7 +237,18 @@
             @click.self="closeMenu()"
         >
             <div class="menu-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="menu-modal-title">
-                <button type="button" class="menu-modal__close" aria-label="關閉菜單視窗" @click="closeMenu" ref="menuCloseRef">&times;</button>
+                <button
+                    type="button"
+                    class="menu-modal__close"
+                    aria-label="關閉菜單視窗"
+                    @click="closeMenu()"
+                    @keydown.enter.prevent="closeMenu()"
+                    @keydown.space.prevent="closeMenu()"
+                    ref="menuCloseRef"
+                >
+                    <span aria-hidden="true">&times;</span>
+                    <span class="sr-only">關閉菜單視窗</span>
+                </button>
                 <div class="menu-modal__header">
                     <p class="menu-modal__subtitle">餐點菜單</p>
                     <h2 id="menu-modal-title" class="menu-modal__title">{{ activeMenuFacility?.name || '' }}</h2>

--- a/styles.css
+++ b/styles.css
@@ -549,8 +549,8 @@ body.menu-modal-open {
 }
 
 .menu-modal__dialog {
-    width: min(540px, 100%);
-    max-height: min(90vh, 720px);
+    width: min(540px, calc(100% - 32px));
+    max-height: min(calc(100vh - 32px), 720px);
     background: var(--surface);
     border-radius: 24px;
     box-shadow: 0 28px 60px rgba(15, 23, 42, 0.2);
@@ -591,19 +591,21 @@ body.menu-modal-open {
     position: absolute;
     top: 18px;
     right: 18px;
-    width: 36px;
-    height: 36px;
+    width: 44px;
+    height: 44px;
     border-radius: 999px;
     border: none;
     background: rgba(255, 255, 255, 0.9);
     color: var(--text);
-    font-size: 1.3rem;
+    font-size: 1.6rem;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
     box-shadow: 0 6px 18px rgba(15, 23, 42, 0.12);
     transition: background 0.2s ease, transform 0.2s ease;
+    line-height: 1;
+    touch-action: manipulation;
 }
 
 .menu-modal__close:hover,
@@ -757,6 +759,7 @@ body.menu-modal-open {
 
     .menu-modal__dialog {
         width: min(92vw, 480px);
+        max-height: min(calc(100vh - 48px), 680px);
     }
 
     .menu-modal__header {
@@ -815,12 +818,14 @@ body.menu-modal-open {
 
 @media (max-width: 480px) {
     .menu-modal {
-        padding: clamp(12px, 4vw, 18px);
+        align-items: flex-end;
+        padding: clamp(12px, 4vw, 18px) clamp(12px, 5vw, 20px) calc(12px + env(safe-area-inset-bottom));
     }
 
     .menu-modal__dialog {
         width: 100%;
-        border-radius: 20px;
+        border-radius: 20px 20px 0 0;
+        max-height: calc(100vh - env(safe-area-inset-top) - clamp(48px, 12vw, 96px));
     }
 
     .menu-modal__header {
@@ -842,7 +847,8 @@ body.menu-modal-open {
 
     .menu-card__image {
         width: 100%;
-        height: 160px;
+        aspect-ratio: 4 / 3;
+        height: auto;
     }
 
     .menu-card__content {


### PR DESCRIPTION
## Summary
- enlarge and harden the menu modal close control with keyboard bindings for reliable dismissal
- refresh the modal layout on small screens to align as a bottom sheet and keep imagery proportional

## Testing
- Manual QA: opened the site locally, triggered a food menu on a mobile viewport, and verified the modal layout and close button


------
https://chatgpt.com/codex/tasks/task_e_68e30ba685a08324975998567e9bbf47