### PR TITLE
Update mobile menu styling and fix modal close button

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@
                     type="button"
                     class="menu-modal__close"
                     aria-label="關閉菜單視窗"
-                    @click="closeMenu()"
+                    @click.stop="closeMenu()"
                     @keydown.enter.prevent="closeMenu()"
                     @keydown.space.prevent="closeMenu()"
                     ref="menuCloseRef"

--- a/styles.css
+++ b/styles.css
@@ -551,14 +551,15 @@ body.menu-modal-open {
 .menu-modal__dialog {
     width: min(540px, calc(100% - 32px));
     max-height: min(calc(100vh - 32px), 720px);
-    background: var(--surface);
+    background: rgba(245, 247, 255, 0.96);
     border-radius: 24px;
-    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.2);
+    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.22);
     display: flex;
     flex-direction: column;
     overflow: hidden;
     transform: translateY(16px);
     transition: transform 0.25s ease;
+    border: 1px solid rgba(99, 102, 241, 0.08);
 }
 
 .menu-modal.visible .menu-modal__dialog {
@@ -566,24 +567,26 @@ body.menu-modal-open {
 }
 
 .menu-modal__header {
-    padding: 28px 32px 18px;
-    background: linear-gradient(145deg, rgba(44, 123, 229, 0.12) 0%, rgba(99, 102, 241, 0.08) 100%);
+    padding: 26px 32px 18px;
+    background: rgba(255, 255, 255, 0.95);
     position: relative;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+    box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.4);
 }
 
 .menu-modal__subtitle {
     margin: 0 0 6px;
-    font-size: 0.9rem;
+    font-size: 0.84rem;
     font-weight: 600;
-    color: rgba(44, 62, 80, 0.7);
-    letter-spacing: 0.04em;
+    color: rgba(71, 85, 105, 0.75);
+    letter-spacing: 0.08em;
     text-transform: uppercase;
 }
 
 .menu-modal__title {
     margin: 0;
-    font-size: 1.35rem;
-    line-height: 1.4;
+    font-size: 1.32rem;
+    line-height: 1.35;
     color: var(--text);
 }
 
@@ -595,7 +598,7 @@ body.menu-modal-open {
     height: 44px;
     border-radius: 999px;
     border: none;
-    background: rgba(255, 255, 255, 0.9);
+    background: rgba(255, 255, 255, 0.95);
     color: var(--text);
     font-size: 1.6rem;
     display: inline-flex;
@@ -606,6 +609,7 @@ body.menu-modal-open {
     transition: background 0.2s ease, transform 0.2s ease;
     line-height: 1;
     touch-action: manipulation;
+    z-index: 1;
 }
 
 .menu-modal__close:hover,
@@ -620,11 +624,12 @@ body.menu-modal-open {
 }
 
 .menu-modal__body {
-    padding: 24px 32px 32px;
+    padding: 24px 28px 28px;
     overflow-y: auto;
     display: flex;
     flex-direction: column;
     gap: 16px;
+    background: linear-gradient(180deg, rgba(248, 250, 255, 0.94) 0%, rgba(241, 245, 255, 0.9) 100%);
 }
 
 .menu-modal__list {
@@ -637,46 +642,49 @@ body.menu-modal-open {
     display: flex;
     align-items: center;
     gap: 16px;
-    padding: 16px;
+    padding: 16px 18px;
     border-radius: 18px;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(238, 244, 255, 0.9));
-    box-shadow: inset 0 0 0 1px rgba(44, 123, 229, 0.08), 0 10px 25px rgba(15, 23, 42, 0.05);
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.04);
+    border: 1px solid rgba(148, 163, 184, 0.22);
 }
 
 .menu-card__image {
-    width: 78px;
-    height: 78px;
-    border-radius: 18px;
+    width: 76px;
+    height: 76px;
+    border-radius: 16px;
     object-fit: cover;
     flex-shrink: 0;
-    background: rgba(44, 123, 229, 0.12);
-    box-shadow: inset 0 0 0 1px rgba(44, 123, 229, 0.18);
+    background: rgba(96, 165, 250, 0.15);
+    box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.2);
 }
 
 .menu-card__content {
     display: flex;
     flex-direction: column;
     gap: 6px;
+    flex: 1 1 auto;
 }
 
 .menu-card__title {
     margin: 0;
-    font-size: 1.05rem;
+    font-size: 1.02rem;
     font-weight: 700;
     color: var(--text);
+    line-height: 1.4;
 }
 
 .menu-card__subtitle {
     margin: 0;
-    font-size: 0.88rem;
-    color: rgba(82, 96, 109, 0.85);
+    font-size: 0.86rem;
+    color: rgba(71, 85, 105, 0.75);
 }
 
 .menu-card__price {
     margin: 0;
-    font-size: 0.95rem;
+    font-size: 0.92rem;
     font-weight: 600;
-    color: var(--primary-dark);
+    color: rgba(37, 99, 235, 0.9);
 }
 
 .menu-modal__empty {
@@ -760,10 +768,11 @@ body.menu-modal-open {
     .menu-modal__dialog {
         width: min(92vw, 480px);
         max-height: min(calc(100vh - 48px), 680px);
+        border-radius: 22px;
     }
 
     .menu-modal__header {
-        padding: 22px 24px 16px;
+        padding: 22px 26px 16px;
     }
 
     .menu-modal__body {
@@ -771,13 +780,15 @@ body.menu-modal-open {
     }
 
     .menu-card {
-        align-items: flex-start;
-        gap: 12px;
+        align-items: center;
+        gap: 14px;
+        padding: 16px 18px;
     }
 
     .menu-card__image {
-        width: 64px;
-        height: 64px;
+        width: 68px;
+        height: 68px;
+        border-radius: 15px;
     }
 
     #mobile-list-toggle {
@@ -829,7 +840,7 @@ body.menu-modal-open {
     }
 
     .menu-modal__header {
-        padding: 18px 20px 14px;
+        padding: 20px 22px 14px;
     }
 
     .menu-modal__title {
@@ -841,14 +852,14 @@ body.menu-modal-open {
     }
 
     .menu-card {
-        flex-direction: column;
-        align-items: stretch;
+        gap: 12px;
+        padding: 15px 16px;
     }
 
     .menu-card__image {
-        width: 100%;
-        aspect-ratio: 4 / 3;
-        height: auto;
+        width: 64px;
+        height: 64px;
+        border-radius: 14px;
     }
 
     .menu-card__content {


### PR DESCRIPTION
## Summary
- ensure the menu modal close control consumes tap events so the sheet can be dismissed on mobile
- restyle the mobile menu modal and cards to better match the desired presentation

## Testing
- Manual QA: Loaded index.html locally, opened the menu modal on a mobile viewport, and verified the refreshed styling and working close button


------
https://chatgpt.com/codex/tasks/task_e_68e31481e26c8324935b9cb8844ee218