### PR TITLE
Show Korean names in menu modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,6 +271,7 @@
                             >
                             <div class="menu-card__content">
                                 <h4 class="menu-card__title">{{ formatMenuName(menuItem) }}</h4>
+                                <p v-if="formatMenuKorean(menuItem)" class="menu-card__subtitle">{{ formatMenuKorean(menuItem) }}</p>
                                 <p v-if="formatMenuSubtitle(menuItem)" class="menu-card__subtitle">{{ formatMenuSubtitle(menuItem) }}</p>
                                 <p v-if="formatMenuPrice(menuItem.menuPrice)" class="menu-card__price">價格：{{ formatMenuPrice(menuItem.menuPrice) }}</p>
                             </div>

--- a/script.js
+++ b/script.js
@@ -118,10 +118,17 @@ createApp({
             return candidates.find(text => typeof text === 'string' && text.trim().length > 0)?.trim() || '餐點';
         };
 
+        const formatMenuKorean = (menuItem) => {
+            const koreanName = typeof menuItem?.menuDescrt === 'string' ? menuItem.menuDescrt.trim() : '';
+            const mainName = formatMenuName(menuItem);
+            return koreanName && koreanName !== mainName ? koreanName : '';
+        };
+
         const formatMenuSubtitle = (menuItem) => {
             const englishName = typeof menuItem?.menuDescrtEng === 'string' ? menuItem.menuDescrtEng.trim() : '';
             const mainName = formatMenuName(menuItem);
-            return englishName && englishName !== mainName ? englishName : '';
+            const koreanName = formatMenuKorean(menuItem);
+            return englishName && englishName !== mainName && englishName !== koreanName ? englishName : '';
         };
 
         const formatMenuPrice = (price) => {
@@ -657,6 +664,7 @@ createApp({
             closeMenu,
             selectZone,
             formatMenuName,
+            formatMenuKorean,
             formatMenuSubtitle,
             formatMenuPrice,
             resetFilters,


### PR DESCRIPTION
## Summary
- display Korean menu entries between the Chinese title and English subtitle within the menu modal
- add formatting helper to expose Korean names without duplicating existing labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e31bfbe33c8324be62664aabeffb6d