### PR TITLE
Add Korean menu names between Chinese and English labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,6 +274,10 @@
                             >
                             <div class="menu-card__content">
                                 <h4 class="menu-card__title">{{ formatMenuName(menuItem) }}</h4>
+                                <p
+                                    v-if="formatMenuKoreanName(menuItem)"
+                                    class="menu-card__subtitle"
+                                >{{ formatMenuKoreanName(menuItem) }}</p>
                                 <p v-if="formatMenuSubtitle(menuItem)" class="menu-card__subtitle">{{ formatMenuSubtitle(menuItem) }}</p>
                                 <p v-if="formatMenuPrice(menuItem.menuPrice)" class="menu-card__price">價格：{{ formatMenuPrice(menuItem.menuPrice) }}</p>
                             </div>

--- a/script.js
+++ b/script.js
@@ -113,13 +113,23 @@ createApp({
             }
         };
 
+        const getTrimmedText = (value) => (typeof value === 'string' ? value.trim() : '');
+
         const formatMenuName = (menuItem) => {
-            const candidates = [menuItem?.menuDescrtCN, menuItem?.menuDescrtEng, menuItem?.menuDescrt];
-            return candidates.find(text => typeof text === 'string' && text.trim().length > 0)?.trim() || '餐點';
+            const chineseName = getTrimmedText(menuItem?.menuDescrtCN);
+            const englishName = getTrimmedText(menuItem?.menuDescrtEng);
+            const koreanName = getTrimmedText(menuItem?.menuDescrt);
+            return chineseName || englishName || koreanName || '餐點';
+        };
+
+        const formatMenuKoreanName = (menuItem) => {
+            const koreanName = getTrimmedText(menuItem?.menuDescrt);
+            const mainName = formatMenuName(menuItem);
+            return koreanName && koreanName !== mainName ? koreanName : '';
         };
 
         const formatMenuSubtitle = (menuItem) => {
-            const englishName = typeof menuItem?.menuDescrtEng === 'string' ? menuItem.menuDescrtEng.trim() : '';
+            const englishName = getTrimmedText(menuItem?.menuDescrtEng);
             const mainName = formatMenuName(menuItem);
             return englishName && englishName !== mainName ? englishName : '';
         };
@@ -657,6 +667,7 @@ createApp({
             closeMenu,
             selectZone,
             formatMenuName,
+            formatMenuKoreanName,
             formatMenuSubtitle,
             formatMenuPrice,
             resetFilters,


### PR DESCRIPTION
## Summary
- show Korean menu names between the Chinese title and English subtitle in the menu modal
- share trimming utility to support the new Korean formatting helper

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68e32ab893d88324b89f3f9e094bc646