### PR TITLE
Adjust mobile map layout to remove blank space

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,7 @@
     --text: #111827;
     --text-subtle: #64748b;
     --shadow-soft: 0 12px 28px rgba(15, 23, 42, 0.08);
+    --header-height: 72px;
 }
 
 * {
@@ -49,6 +50,7 @@ h1 {
     background: rgba(255, 255, 255, 0.96);
     backdrop-filter: blur(10px);
     border-bottom: 1px solid rgba(226, 232, 240, 0.8);
+    min-height: var(--header-height);
 }
 
 .app-title {
@@ -720,18 +722,27 @@ body.menu-modal-open {
     }
 
     .container {
+        flex: 1 1 auto;
         flex-direction: column;
         padding: 0;
         width: 100%;
+        gap: 0;
         min-height: 0;
+        height: calc(100vh - var(--header-height));
+    }
+
+    @supports (height: 100dvh) {
+        .container {
+            height: calc(100dvh - var(--header-height));
+        }
     }
 
     .map-container {
-        flex: 1 1 auto;
         border-radius: 0;
         border: none;
         box-shadow: none;
-        min-height: 55vh;
+        flex: 1 1 auto;
+        min-height: 0;
     }
 
     .facility-list {


### PR DESCRIPTION
## Summary
- define a shared header height variable for consistent layout spacing
- update the mobile container sizing to fill the viewport and eliminate the blank region beneath the map
- ensure the mobile map container flexes to the full height so the map remains visible behind the facility list

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e465a94dbc8324b56b8f673f338769